### PR TITLE
Support reading manifest.json from an uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,25 @@ WebpackManifest::Rails.configuration do |c|
 end
 ```
 
-### Multiple manifest files support
+#### Live reloading in development
+
+Optionally you can integrate the gem with [webpack-dev-server](https://github.com/webpack/webpack-dev-server) to enable live reloading by setting an manifest url served by webpack-dev-server, instead of a local file path. This should be used for development only.
+
+Note that WebpackManifest itself does not launches webpack-dev-server, so it must be started along with Rails server by yourself.
+
+```rb
+WebpackManifest::Rails.configuration do |c|
+  c.cache = !Rails.env.development?
+
+  c.manifest = if Rails.env.development?
+                 'http://localhost:8080/packs/manifest.json'
+               else
+                 Rails.root.join('public', 'assets', 'manifest.json')
+               end
+end
+```
+
+#### Multiple manifest files support
 
 This is optional. You can register multiple manifest files for the view helpers. This feature must be useful if your Rails project serves for several sites, then asset bundling process is isolated every site.
 

--- a/lib/webpack_manifest/manifest.rb
+++ b/lib/webpack_manifest/manifest.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'open-uri'
+require 'uri'
 
 module WebpackManifest
   class Manifest
@@ -42,8 +44,16 @@ module WebpackManifest
     end
 
     def load_data
-      raise(FileNotFoundError, "#{@path}: no such manifest found") unless File.exist?(@path)
-      JSON.parse(File.read(@path))
+      u = URI.parse(@path)
+      data = nil
+      if u.scheme == 'file' || u.path == @path  # file path
+        raise(FileNotFoundError, "#{@path}: no such manifest found") unless File.exist?(@path)
+        data = File.read(@path)
+      else
+        # http url
+        data = u.read
+      end
+      JSON.parse(data)
     end
 
     def handle_missing_entry(name)

--- a/lib/webpack_manifest/manifest.rb
+++ b/lib/webpack_manifest/manifest.rb
@@ -13,7 +13,7 @@ module WebpackManifest
     attr_writer :cache
 
     def initialize(path, cache: false)
-      @path = path
+      @path = path.to_s
       @cache = cache
     end
 

--- a/lib/webpack_manifest/manifest.rb
+++ b/lib/webpack_manifest/manifest.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'pathname'
 
 module WebpackManifest
   class Manifest
@@ -12,7 +11,7 @@ module WebpackManifest
     attr_writer :cache
 
     def initialize(path, cache: false)
-      @path = Pathname.new(path)
+      @path = path
       @cache = cache
     end
 

--- a/spec/webpack_manifest/manifest_spec.rb
+++ b/spec/webpack_manifest/manifest_spec.rb
@@ -5,21 +5,12 @@ require 'webpack_manifest/manifest'
 
 RSpec.describe WebpackManifest::Manifest do
   describe '.new' do
-    subject { described_class.new(path) }
+    subject { described_class.new(path, cache: cache) }
 
-    context 'with String' do
-      let(:path) { 'webpack-assets.json' }
+    let(:path) { 'webpack-assets.json' }
+    let(:cache) { true }
 
-      it { is_expected.to be_a described_class }
-      it { expect(subject.path).to eq Pathname.new(path) }
-    end
-
-    context 'with Pathname' do
-      let(:path) { Pathname.new('webpack-assets.json') }
-
-      it { is_expected.to be_a described_class }
-      it { expect(subject.path).to eq path }
-    end
+    it { is_expected.to be_a described_class }
   end
 
   describe '#lookup!' do

--- a/spec/webpack_manifest/manifest_spec.rb
+++ b/spec/webpack_manifest/manifest_spec.rb
@@ -46,5 +46,22 @@ RSpec.describe WebpackManifest::Manifest do
 
       it { expect { subject }.to raise_error WebpackManifest::Manifest::FileNotFoundError }
     end
+
+    context 'when an uri is given' do
+      let(:path) { 'http://localhost:8080/packs/manifest.json' }
+      let(:stub_uri) do
+        instance_double('URI::HTTP',
+                        scheme: 'http',
+                        path: 'packs/manifest.json',
+                        read: data)
+      end
+      let(:data) do
+        { 'foo.js' => '/assets/foo-9a55da116417a39a9d1b.js.json' }.to_json
+      end
+
+      before { allow(URI).to receive(:parse).and_return(stub_uri) }
+
+      it { is_expected.to eq JSON.parse(data) }
+    end
   end
 end

--- a/spec/webpack_manifest/manifest_spec.rb
+++ b/spec/webpack_manifest/manifest_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'webpack_manifest/manifest'
+require 'pathname'
 
 RSpec.describe WebpackManifest::Manifest do
   describe '.new' do
@@ -41,10 +42,10 @@ RSpec.describe WebpackManifest::Manifest do
       it { is_expected.to eq JSON.parse(File.read(path)) }
     end
 
-    context 'when non-existing manifest is given' do
-      let(:path) { 'not/found/path' }
+    context 'when Pathname object is given' do
+      let(:path) { Pathname.new(File.expand_path('../support/files/manifest.json', __dir__)) }
 
-      it { expect { subject }.to raise_error WebpackManifest::Manifest::FileNotFoundError }
+      it { is_expected.to eq JSON.parse(File.read(path.to_s)) }
     end
 
     context 'when an uri is given' do
@@ -62,6 +63,12 @@ RSpec.describe WebpackManifest::Manifest do
       before { allow(URI).to receive(:parse).and_return(stub_uri) }
 
       it { is_expected.to eq JSON.parse(data) }
+    end
+
+    context 'when non-existing manifest is given' do
+      let(:path) { 'not/found/path' }
+
+      it { expect { subject }.to raise_error WebpackManifest::Manifest::FileNotFoundError }
     end
   end
 end

--- a/spec/webpack_manifest/rails/configuration_spec.rb
+++ b/spec/webpack_manifest/rails/configuration_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe WebpackManifest::Rails::Configuration do
     end
 
     it 'resigters a manifest as a default' do
-      expect(config.manifests.default.path).to eq Pathname.new('public/manifest.json')
+      expect(config.manifests.default.path).to eq 'public/manifest.json'
     end
     it 'resigters a manifest with cache false by default' do
       expect(config.manifests.default.cache_enabled?).to eq false
@@ -37,7 +37,7 @@ RSpec.describe WebpackManifest::Rails::Configuration do
 
     it 'registers a manifest' do
       expect(config.manifests.get(:shop)).to be_a WebpackManifest::Manifest
-      expect(config.manifests.get(:shop).path).to eq Pathname.new('public/manifest.json')
+      expect(config.manifests.get(:shop).path).to eq 'public/manifest.json'
     end
 
     context 'with cache enable config' do

--- a/spec/webpack_manifest/rails/manifest_repository_spec.rb
+++ b/spec/webpack_manifest/rails/manifest_repository_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WebpackManifest::Rails::ManifestRepository do
 
       it 'registers a manifest' do
         expect(repository.get(:shop)).to be_a WebpackManifest::Manifest
-        expect(repository.get(:shop).path).to eq Pathname.new('public/manifest.json')
+        expect(repository.get(:shop).path).to eq 'public/manifest.json'
       end
       it 'marks registered manifest as a default' do
         expect(repository.default).to eq repository.get(:shop)
@@ -28,14 +28,14 @@ RSpec.describe WebpackManifest::Rails::ManifestRepository do
 
       it 'registers the shop manifest' do
         expect(repository.get(:shop)).to be_a WebpackManifest::Manifest
-        expect(repository.get(:shop).path).to eq Pathname.new('public/manifest-shop.json')
+        expect(repository.get(:shop).path).to eq 'public/manifest-shop.json'
       end
       it 'marks the first manifest as a default' do
         expect(repository.default).to eq repository.get(:shop)
       end
       it 'registers the admin manifest' do
         expect(repository.get(:admin)).to be_a WebpackManifest::Manifest
-        expect(repository.get(:admin).path).to eq Pathname.new('public/manifest-admin.json')
+        expect(repository.get(:admin).path).to eq 'public/manifest-admin.json'
       end
     end
 

--- a/spec/webpack_manifest/rails/manifest_repository_spec.rb
+++ b/spec/webpack_manifest/rails/manifest_repository_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe WebpackManifest::Rails::ManifestRepository do
 
       it 'gets a registered manifest' do
         expect(repository.get(:shop)).to be_a WebpackManifest::Manifest
-        expect(repository.get(:shop).path).to eq Pathname.new('public/manifest.json')
+        expect(repository.get(:shop).path).to eq 'public/manifest.json'
       end
     end
 


### PR DESCRIPTION
This enables the gem to read remote manifest.json which is served via HTTP. An example configuration is as below:

```
WebpackManifest::Rails.configuration do |c|
  ...
  c.manifest = 'http://localhost:8080/packs/manifest.json'
  ...
end
```

The background of this enhancement is to supporting Hot Module Replacement by webpack-dev-server. manifest.json is served via HTTP, not from file system, by webpack-dev-server. Therefore, this should be useful.