### PR TITLE
Add helpers for js and css for Webpack4's splitChunks feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased / yyyy-mm-dd
+
+## Enhancements:
+
+* Added `javascript_bundles_with_chunks_tag` and `stylesheet_bundles_with_chunks_tag` helpers, which creates html tags for a pack and all the dependent chunks, when using splitChunks. (#7)
+
 # 0.2.3 / 2018-11-18
 
 * Support passing symbols to helper methods (#5) by @jmortlock

--- a/README.md
+++ b/README.md
@@ -104,6 +104,54 @@ image_bundle_tag "icon.png", size: "16x10", alt: "Edit Entry"
         height="10" alt="Edit Entry" />
 ```
 
+
+#### `javascript_bundles_with_chunks_tag` and `stylesheet_bundles_with_chunks_tag`
+
+**Experimental** These are the helpers, which are similar to Webpacker, to support `splitChunks` feature introduced since Webpack 4.
+
+For the full configuration options of splitChunks, see the Webpack's [documentation](https://webpack.js.org/plugins/split-chunks-plugin/).
+
+Then use the `javascript_bundles_with_chunks_tag` and `stylesheet_bundles_with_chunks_tag` helpers to include all
+the transpiled packs with the chunks in your view, which creates html tags for all the chunks.
+
+```
+<%= javascript_bundles_with_chunks_tag 'calendar', 'map', 'data-turbolinks-track': 'reload' %>
+
+<!-- Creates the following: -->
+<script src="/packs/vendor-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/calendar-1016838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map~runtime-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+<script src="/packs/map-16838bab065ae1e314.js" data-turbolinks-track="reload"></script>
+```
+
+**Important:** Pass all your pack names to the helper otherwise you will get duplicated chunks on the page.
+
+```
+<%# DO %>
+<%= javascript_bundles_with_chunks_tag 'calendar', 'map' %>
+
+<%# DON'T %>
+<%= javascript_bundles_with_chunks_tag 'calendar' %>
+<%= javascript_bundles_with_chunks_tag 'map' %>
+```
+
+**Important:** Also, these helpers do not work with `webpack-manifest-plugin` npm because it has no support to generate a manifest with a set of of chunk entries https://github.com/danethurber/webpack-manifest-plugin/issues/133. Instead, [webpack-assets-manifest](https://github.com/webdeveric/webpack-assets-manifest) npm supports. Please change the plugin for manifest file generation if you wish to enable `splitChunks` feature.
+
+```
+const WebpackAssetsManifest = require('webpack-assets-manifest');
+
+module.exports = {
+  // ...
+  plugins: [
+    new WebpackAssetsManifest({
+      entrypoints: true, // Please set this as true
+    })
+  ],
+  // ...
+}
+```
+
 ## Advanced Configuration
 
 ### Hot Module Replacement in development

--- a/spec/support/files/manifest-admin.json
+++ b/spec/support/files/manifest-admin.json
@@ -1,5 +1,19 @@
 {
   "admin-application.css": "/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.css",
   "admin-application.js": "/packs/admin/admin-application-5d7c7164b8a0a9d675fad9ab410eaa8d.js",
-  "admin-icon.png": "/packs/admin/admin-icon-5d7c7164b8a0a9d675fad9ab410eaa8d.png"
+  "admin-icon.png": "/packs/admin/admin-icon-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+  "entrypoints": {
+    "admin-application": {
+      "js": [
+        "/packs/vendors~admin-application-e55f2aae30c07fb6d82a.chunk.js",
+        "/packs/admin-application-k344a6d59eef8632c9d1.js"
+      ]
+    },
+   "admin-hello_stimulus": {
+      "css": [
+        "/packs/1-c20632e7baf2c81200d3.chunk.css",
+        "/packs/admin-hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
+      ]
+    }
+  }
 }

--- a/spec/support/files/manifest.json
+++ b/spec/support/files/manifest.json
@@ -6,5 +6,24 @@
   "item_group_editor.js": "/packs/item_group_editor-857e5bfa272e71b6384046f68ba29d44.js",
   "item_group_editor.js.map": "/packs/item_group_editor.js.map",
   "union-ok.png": "/packs/union-ok-857e5bfa272e71b6384046f68ba29d44.png",
-  "union-ok@2x.png": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png"
+  "union-ok@2x.png": "/packs/union-ok@2x-5d7c7164b8a0a9d675fad9ab410eaa8d.png",
+  "entrypoints": {
+    "application": {
+      "js": [
+        "/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js",
+        "/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js",
+        "/packs/application-k344a6d59eef8632c9d1.js"
+      ],
+      "css": [
+        "/packs/1-c20632e7baf2c81200d3.chunk.css",
+        "/packs/application-k344a6d59eef8632c9d1.chunk.css"
+      ]
+    },
+    "hello_stimulus": {
+      "css": [
+        "/packs/1-c20632e7baf2c81200d3.chunk.css",
+        "/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css"
+      ]
+    }
+  }
 }

--- a/spec/webpack_manifest/manifest_spec.rb
+++ b/spec/webpack_manifest/manifest_spec.rb
@@ -14,6 +14,48 @@ RSpec.describe WebpackManifest::Manifest do
     it { is_expected.to be_a described_class }
   end
 
+  describe '#lookup_pack_with_chunks!' do
+    subject { described_class.new(path, cache: false).lookup_pack_with_chunks!(name, type: type) }
+
+    let(:path) { File.expand_path('../support/files/manifest.json', __dir__) }
+    let(:type) { nil }
+
+    context 'with name with ext' do
+      let(:name) { 'application.js' }
+
+      it do
+        is_expected.to eq(
+          %w(
+            /packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js
+            /packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js
+            /packs/application-k344a6d59eef8632c9d1.js
+          )
+        )
+      end
+    end
+
+    context 'with name without ext' do
+      let(:name) { 'application' }
+      let(:type) { 'js' }
+
+      it do
+        is_expected.to eq(
+          %w(
+            /packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js
+            /packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js
+            /packs/application-k344a6d59eef8632c9d1.js
+          )
+        )
+      end
+    end
+
+    context 'when non exist name is given' do
+      let(:name) { 'foo.js' }
+
+      it { expect { subject }.to raise_error WebpackManifest::Manifest::MissingEntryError }
+    end
+  end
+
   describe '#lookup!' do
     subject { described_class.new(path, cache: cache).lookup!(name) }
 

--- a/spec/webpack_manifest/rails/helper_spec.rb
+++ b/spec/webpack_manifest/rails/helper_spec.rb
@@ -114,6 +114,62 @@ RSpec.describe WebpackManifest::Rails::Helper do
     end
   end
 
+  describe '#javascript_bundles_with_chunks_tag' do
+    context 'given existing *.js entry name' do
+      subject { helper.javascript_bundles_with_chunks_tag('application') }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js"></script>\n) +
+          %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+          %(<script src="/packs/application-k344a6d59eef8632c9d1.js"></script>),
+        )
+      end
+    end
+
+    context 'given existing *.js entry name with an option' do
+      subject { helper.javascript_bundles_with_chunks_tag('application', 'data-turbolinks-track': 'reload') }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<script src="/packs/vendors~application~bootstrap-c20632e7baf2c81200d3.chunk.js" data-turbolinks-track="reload"></script>\n) +
+          %(<script src="/packs/vendors~application-e55f2aae30c07fb6d82a.chunk.js" data-turbolinks-track="reload"></script>\n) +
+          %(<script src="/packs/application-k344a6d59eef8632c9d1.js" data-turbolinks-track="reload"></script>),
+        )
+      end
+    end
+
+    context 'with multiple manifests registration and with manifest: option' do
+      subject { helper.javascript_bundles_with_chunks_tag('admin-application', manifest: :admin) }
+
+      let(:manifest_admin_path) { File.expand_path('../../support/files/manifest-admin.json', __dir__) }
+      let(:configuration) do
+        WebpackManifest::Rails::Configuration.new.tap do |c|
+          c.cache = false
+          c.add :shop, manifest_path
+          c.add :admin, manifest_admin_path
+        end
+      end
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<script src="/packs/vendors~admin-application-e55f2aae30c07fb6d82a.chunk.js"></script>\n) +
+          %(<script src="/packs/admin-application-k344a6d59eef8632c9d1.js"></script>),
+        )
+      end
+    end
+
+    context 'given non-existing *.js entry name' do
+      subject do
+        -> { helper.javascript_bundles_with_chunks_tag('not_found') }
+      end
+
+      it 'raises' do
+        is_expected.to raise_error WebpackManifest::Manifest::MissingEntryError
+      end
+    end
+  end
+
   describe '#stylesheet_bundle_tag' do
     context 'given existing *.css entry name' do
       subject { helper.stylesheet_bundle_tag('item_group_editor') }
@@ -151,6 +207,60 @@ RSpec.describe WebpackManifest::Rails::Helper do
     context 'given non-existing *.css entry name' do
       subject do
         -> { helper.stylesheet_bundle_tag('not_found') }
+      end
+
+      it 'raises' do
+        is_expected.to raise_error WebpackManifest::Manifest::MissingEntryError
+      end
+    end
+  end
+
+  describe '#stylesheet_bundles_with_chunks_tag' do
+    context 'given existing *.css entry name' do
+      subject { helper.stylesheet_bundles_with_chunks_tag('hello_stimulus') }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+          %(<link rel="stylesheet" media="screen" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+        )
+      end
+    end
+
+    context 'given existing *.css entry name with an option' do
+      subject { helper.stylesheet_bundles_with_chunks_tag('hello_stimulus', media: 'all') }
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<link rel="stylesheet" media="all" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+          %(<link rel="stylesheet" media="all" href="/packs/hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+        )
+      end
+    end
+
+    context 'with multiple manifests registration and with manifest: option' do
+      subject { helper.stylesheet_bundles_with_chunks_tag('admin-hello_stimulus', manifest: :admin) }
+
+      let(:manifest_admin_path) { File.expand_path('../../support/files/manifest-admin.json', __dir__) }
+      let(:configuration) do
+        WebpackManifest::Rails::Configuration.new.tap do |c|
+          c.cache = false
+          c.add :shop, manifest_path
+          c.add :admin, manifest_admin_path
+        end
+      end
+
+      it 'renders tags for chunk assets' do
+        is_expected.to eq(
+          %(<link rel="stylesheet" media="screen" href="/packs/1-c20632e7baf2c81200d3.chunk.css" />\n) +
+          %(<link rel="stylesheet" media="screen" href="/packs/admin-hello_stimulus-k344a6d59eef8632c9d1.chunk.css" />),
+        )
+      end
+    end
+
+    context 'given non-existing *.css entry name' do
+      subject do
+        -> { helper.stylesheet_bundles_with_chunks_tag('not_found') }
       end
 
       it 'raises' do


### PR DESCRIPTION
Like Webpacker, introduced two helper `javascript_bundles_with_chunks_tag` and `stylesheet_bundles_with_chunks_tag`. The purpose is to support `splitChunks` feature that Webpacker provides.

**Note**

Currently `webpack-manifest-plugin` does not generate a manifest with grouping chunk entries as arrays https://github.com/danethurber/webpack-manifest-plugin/issues/181. Webpacker swithced to [webpack-assets-manifest](https://github.com/webdeveric/webpack-assets-manifest) npm on the work https://github.com/rails/webpacker/pull/1316. So, right now in order to these introduced helpers, you have to switch to webpack-assets-manifest npm.