### PR TITLE
Fix CI failure on ruby head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - 2.5.3
   - 2.6.0
   - ruby-head
-before_install: gem install bundler -v 1.16.6
+before_install: gem install bundler -v 2.0.1

--- a/webpack_manifest.gemspec
+++ b/webpack_manifest.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency 'actionview'
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Use bundler v2.

This will fix `Bundler could not find compatible versions for gem "bundler"`. 