### PR TITLE
Improve configuration system by introducing 2-levels capability

### DIFF
--- a/lib/webpack_manifest/rails/configuration.rb
+++ b/lib/webpack_manifest/rails/configuration.rb
@@ -2,32 +2,106 @@
 
 module WebpackManifest
   module Rails
+    # 1-level or 2-levels configuration system. With the typical single site usecase,
+    # only the root instance exists as a singleton. If you manage more then one site,
+    # each configuration is stored at the 2nd level of the configuration tree.
     class Configuration
-      attr_reader :manifests
+      class Error < StandardError; end
 
-      def initialize
-        # default values
-        @cache = false
-        @manifests = ManifestRepository.new
+      ROOT_DEFAULT_ID = :''
+
+      class << self
+        def config_attr(prop)
+          define_method(prop) do
+            @config.fetch(prop, @parent&.public_send(prop))
+          end
+
+          define_method("#{prop}=".to_sym) do |v|
+            @config[prop] = v
+          end
+        end
       end
 
-      def cache
-        @cache
+      config_attr :id
+
+      config_attr :cache
+
+      config_attr :manifest
+
+      # Initializes a new instance of Configuration class.
+      #
+      # @param [Configuration,nil] parent refenrece to the parent configuration instance.
+      def initialize(parent = nil)
+        @parent = parent
+        # Only a root instance can have children, which are sub configurations each site.
+        @children = {}
+        @config = {}
+
+        # If self is a configuration for a specific site, the getting attrs
+        # not being configured are delegated to the root configuration, so
+        # only root configuration object can have default values.
+        reset_defaults! if root?
       end
 
-      def cache=(v)
-        @manifests.all_manifests.each { |m| m.cache = v }
-        @cache = v
+      # Register a sub configuration with a site name, with a manifest file
+      # optionally. You can configure per site.
+      #
+      # @param [Symbol] id uniq name of the site
+      # @param [String] path path of the manifest file
+      # @yieldparam [Configuration] config a sub configuration instance is sent to the block
+      def add(id, path = nil)
+        raise Error, 'Defining a sub configuration under a sub is not allowed' if leaf?
+
+        id = id.to_sym
+        config = self.class.new(self)
+        config.id = id
+        config.manifest = path unless path.nil?
+
+        # Link the root to the child
+        @children[id] = config
+
+        # The sub configuration can be configured within a block
+        yield config if block_given?
+
+        config
       end
 
-      # Register a single manifest as a default.
-      def manifest=(path)
-        @manifests.default = @manifests.add '', path, cache: @cache
+      # Lookup a sub configuration by it's name
+      #
+      # @param [Symbol] id
+      # @return [Configuration] a sub configuration
+      def sub(id)
+        @children[id]
       end
 
-      # Register a manfiest. You can register multiple files by calling `#add`.
-      def add(key, path)
-        @manifests.add(key, path, cache: @cache)
+      # TODO: This will be moved to WebpackManifest::Rails.manifests in the future.
+      def manifests
+        raise Error, 'Calling #manifests is only allowed from a root' unless root?
+
+        repo = ManifestRepository.new
+        #  Determine if a single manifest mode or multiple manifests(multiple site) mode
+        targets =  @children.empty? ? [self] : @children.values
+        targets.each do |config|
+          repo.add(config.id, config.manifest, cache: config.cache)
+        end
+        repo
+      end
+
+      private
+
+      def reset_defaults!
+        @config = {
+          id: ROOT_DEFAULT_ID,
+          cache: false,
+        }
+      end
+
+      def root?
+        @parent.nil?
+      end
+
+      def leaf?
+        !root?
       end
     end
   end


### PR DESCRIPTION
I intend to introduce a RSpec module to add pre-compilation feature in test mode. To do this, `Configuration` has to be more configurable per site. For example, `base_path`, which is a parameter will be introduced later, to address a base directory of each frontend system, has to become configurable per site, if a Rails project has more than one site. 

```rb
# Note: base_path has not introduced yet.
WebpackManifest::Rails.configuration do |c|
  # The settings called within the root configuration scope are enabled in all sites,
  # which means enabled in :shop and :admin.
  c.cache = !Rails.env.development?

  c.add :shop do |co|
    # These are enabled only in :shop
    co.manifest = Rails.root.join('public', 'assets', 'manifest-shop.json')
    co.base_path = Rails.root.join('frontend', 'shop')
  end

  c.add :admin do |co|
    # These are enabled only in :admin
    co.manifest = Rails.root.join('public', 'assets', 'manifest-admin.json')
    co.base_path = Rails.root.join('frontend', 'admin')
  end
```

This pull request improves `Configuration` class in advance, with backward compatible.
