### PR TITLE
Fix cache missed problem when multi sites are defined

### DIFF
--- a/lib/webpack_manifest/rails.rb
+++ b/lib/webpack_manifest/rails.rb
@@ -24,7 +24,7 @@ module WebpackManifest
       def install(logger: nil)
         configuration.leaves.each do |c|
           watched_paths = INSTALLER_WATCHED_PATHS.map { |f| File.expand_path(f, c.resolved_base_path) }
-          watcher = FileChangeWatcher.new(watched_paths, File.join(c.cache_path, "last-installation-digest-#{::Rails.env}"))
+          watcher = FileChangeWatcher.new(watched_paths, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
           CommandRunner.new(
             {},
             c.install_command,
@@ -37,7 +37,7 @@ module WebpackManifest
 
       def build(logger: nil)
         configuration.leaves.each do |c|
-          watcher = FileChangeWatcher.new(c.resolved_watched_paths, File.join(c.cache_path, "last-build-digest-#{::Rails.env}"))
+          watcher = FileChangeWatcher.new(c.resolved_watched_paths, File.join(c.cache_path, "last-build-digest-#{c.id}-#{::Rails.env}"))
           CommandRunner.new(
             {},
             c.build_command,


### PR DESCRIPTION
`id` must be included in cache file paths.