### PR TITLE
Plugin loader

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,22 @@
+# Plugins
+
+**EXPERIMENTAL:** Extensions that use Minipack plugin API.
+
+Minipack will load plugins installed in gems or $LOAD_PATH. Plugins must be named `minipack_plugin.rb` and placed at the root of your gem.
+
+## Make your own plugin
+
+The first step is to follow the conventional file name, we will check that our plugin is loaded correctly:
+
+```
+$ cat lib/minipack_plugin.rb
+puts 'hello from my plugin!'
+
+$ bin/rails stats
+hello from my plugin!
+...
+```
+
+## Hooks
+
+Right now, no hooks supported. When you consider the hooks feature. Please give me a feedback!

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -14,11 +14,7 @@ module Minipack
 
   INSTALLER_WATCHED_PATHS = ['package.json', 'package-lock.json', 'yarn.lock'].freeze
 
-  @after_initialize_hooks ||= []
-
   class << self
-    attr_reader :after_initialize_hooks
-
     def configuration(&block)
       @configuration ||= Configuration.new
       yield @configuration if block_given?
@@ -52,21 +48,13 @@ module Minipack
         ).run!
       end
     end
-
-    def after_initialize(&hook)
-      @after_initialize_hooks << hook
-    end
   end
 end
-
-# To keep backward compatibility
-require_relative 'webpack_manifest'
 
 require 'active_support/lazy_load_hooks'
 ActiveSupport.on_load :action_view do
   ::ActionView::Base.send :include, Minipack::Helper
 end
 
-ActiveSupport.on_load :after_initialize do
-  Minipack.after_initialize_hooks.each(&:call)
-end
+# To keep backward compatibility
+require_relative 'webpack_manifest'

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -48,13 +48,49 @@ module Minipack
         ).run!
       end
     end
+
+    # Find all 'minipack_plugin' files in $LOAD_PATH and load them
+    def load_env_plugins
+
+      files = []
+      glob = '**/minipack_plugin.rb'
+      $LOAD_PATH.each do |load_path|
+        globbed = Dir.glob(File.expand_path(glob, load_path))
+
+        globbed.each do |load_path_file|
+          files << load_path_file if File.file?(load_path_file)
+        end
+      end
+
+      load_plugin_files files
+    end
+
+    def load_plugins
+      load_plugin_files ::Gem.find_latest_files('minipack/**/minipack_plugin', false)
+    end
+
+    private
+
+    def load_plugin_files(plugins)
+      plugins.each do |plugin|
+        begin
+          load plugin
+        rescue ::Exception => e
+          details = "#{plugin.inspect}: #{e.message} (#{e.class})"
+          warn "Error loading Minipack plugin #{details}"
+        end
+      end
+    end
   end
 end
+
+# To keep backward compatibility
+require_relative 'webpack_manifest'
 
 require 'active_support/lazy_load_hooks'
 ActiveSupport.on_load :action_view do
   ::ActionView::Base.send :include, Minipack::Helper
 end
 
-# To keep backward compatibility
-require_relative 'webpack_manifest'
+Minipack.load_env_plugins
+Minipack.load_plugins

--- a/spec/minipack_spec.rb
+++ b/spec/minipack_spec.rb
@@ -16,12 +16,4 @@ RSpec.describe Minipack do
       end
     end
   end
-
-  describe '.after_initialize' do
-    subject { described_class.after_initialize { } }
-
-    after { described_class.after_initialize_hooks.clear }
-
-    it { expect { subject }.to change { described_class.after_initialize_hooks.size }.by(1) }
-  end
 end

--- a/spec/minipack_spec.rb
+++ b/spec/minipack_spec.rb
@@ -16,4 +16,12 @@ RSpec.describe Minipack do
       end
     end
   end
+
+  describe '.after_initialize' do
+    subject { described_class.after_initialize { } }
+
+    after { described_class.after_initialize_hooks.clear }
+
+    it { expect { subject }.to change { described_class.after_initialize_hooks.size }.by(1) }
+  end
 end


### PR DESCRIPTION
When you write `minipack_plugin.rb`, it will be loaded along side Minipack.
 
ref: https://guides.rubygems.org/plugins/

My expected initialization sequence is as follows:(may change in the future)

```
loading gems by bundler
  |
  v
loading minipack gem
    \
     -> loading minipack plugins' minipack_plugin.rb 
       -> Define config parameters, run anything, or register hooks(not implemented though)
  |
  v
Rails application initialization process
    \
     -> load config/initializers/minipack.rb to setup configuration
  |
  v
call after_initialize hooks? (not implemented)
```