### PR TITLE
Fix bug that watched_paths Array cou be updated

### DIFF
--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -62,7 +62,7 @@ module Minipack
       config_attr :manifest
 
       # The lazy compilation is cached until a file is change under the tracked paths.
-      config_attr :watched_paths, default: WATCHED_PATHS_DEFAULT
+      config_attr :watched_paths, default: WATCHED_PATHS_DEFAULT.dup
 
       # The command for bundling assets
       config_attr :build_command, default: 'node_modules/.bin/webpack'


### PR DESCRIPTION
`config.watched_paths << 'src/**/*'` must have been updatable, but not due to #16