### PR TITLE
Refactor build and pkg install

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ Minipack.configuration do |c|
   # c.build_command = 'npm run build'
 
   # A full package installation command, with it's arguments and options. The command is executed under the `base_path`.
-  # c.install_command = 'npm install'
+  # c.pkg_install_command = 'npm install'
   #
   # If you prefer `yarn`:
-  # c.install_command = 'yarn install'
+  # c.pkg_install_command = 'yarn install'
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,25 +56,27 @@ Minipack.configuration do |c|
   # Note that a base_path can be a relative path from `Rails.root`.
   # c.base_path = 'frontend'
 
-  # When running tests, the lazy compilation is cached until a file is changed
-  # under your tracked paths. You can configure which paths are tracked by
-  # adding new paths to `watched_paths` array. Each path can be a relative path
-  # from the `base_dir`.
+  # You can invokes a command to build assets in node from Minipack.
+  #
+  # When running tests, the lazy compilation is cached until a cache key, based
+  # on file checksum under your tracked paths, is changed. You can configure
+  # which paths are tracked by adding new paths to `build_cache_key`. Each path
+  # can be a relative path from the `base_dir`.
   #
   # The value will be as follows by default:
-  # c.watched_paths = [
+  # c.build_cache_key = [
   #   'package.json', 'package-lock.json', 'yarn.lock', 'webpack.config.js',
   #   'webpackfile.js', 'config/webpack.config.js', 'config/webpackfile.js',
   #   'app/javascripts/**/*',
   # ]
   #
   # You can override it.
-  # c.watched_paths = ['package.json', 'package-lock.json', 'config/webpack.config.js', 'src/**/*'] 
+  # c.build_cache_key = ['package.json', 'package-lock.json', 'config/webpack.config.js', 'src/**/*'] 
   #
   # Or you can add files in addition to the defaults:
-  # c.watched_paths << 'src/**/*'
+  # c.build_cache_key << 'src/**/*'
 
-  # A full webpack command to build assets'. The command you specify is executed under the `base_dir`.
+  # A command to to build assets. The command you specify is executed under the `base_dir`.
   # c.build_command = 'node_modules/.bin/webpack'
   #
   # You may want to customize it with options:
@@ -248,7 +250,7 @@ Minipack.configuration do |c|
     co.manifest = Rails.root.join('public', 'assets', 'manifest-admin.json')
     co.base_path = Rails.root.join('frontend/admin')
     # You can customize all configurable parameters per site.
-    co.watched_paths << 'javascripts/**/*'
+    co.build_cache_key << 'javascripts/**/*'
     co.build_command = 'yarn install'
   end
 end

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -24,8 +24,8 @@ module Minipack
 
     def install(logger: nil)
       configuration.leaves.each do |c|
-        watched_paths = INSTALLER_WATCHED_PATHS.map { |f| File.expand_path(f, c.resolved_base_path) }
-        watcher = FileChangeWatcher.new(watched_paths, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
+        build_cache_key = INSTALLER_WATCHED_PATHS.map { |f| File.expand_path(f, c.resolved_base_path) }
+        watcher = FileChangeWatcher.new(build_cache_key, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
         CommandRunner.new(
           {},
           c.install_command,
@@ -38,7 +38,7 @@ module Minipack
 
     def build(logger: nil)
       configuration.leaves.each do |c|
-        watcher = FileChangeWatcher.new(c.resolved_watched_paths, File.join(c.cache_path, "last-build-digest-#{c.id}-#{::Rails.env}"))
+        watcher = FileChangeWatcher.new(c.resolved_build_cache_key, File.join(c.cache_path, "last-build-digest-#{c.id}-#{::Rails.env}"))
         CommandRunner.new(
           {},
           c.build_command,

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -10,6 +10,7 @@ module Minipack
   require 'minipack/file_change_watcher'
   require 'minipack/command_runner'
   require 'minipack/railtie'
+  require 'minipack/commands/build'
   require "minipack/version"
 
   INSTALLER_WATCHED_PATHS = ['package.json', 'package-lock.json', 'yarn.lock'].freeze
@@ -29,19 +30,6 @@ module Minipack
         CommandRunner.new(
           {},
           c.install_command,
-          chdir: c.resolved_base_path,
-          logger: logger,
-          watcher: watcher,
-        ).run!
-      end
-    end
-
-    def build(logger: nil)
-      configuration.leaves.each do |c|
-        watcher = FileChangeWatcher.new(c.resolved_build_cache_key, File.join(c.cache_path, "last-build-digest-#{c.id}-#{::Rails.env}"))
-        CommandRunner.new(
-          {},
-          c.build_command,
           chdir: c.resolved_base_path,
           logger: logger,
           watcher: watcher,

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -10,10 +10,10 @@ module Minipack
   require 'minipack/file_change_watcher'
   require 'minipack/command_runner'
   require 'minipack/railtie'
+  require 'minipack/commands/base'
   require 'minipack/commands/build'
+  require 'minipack/commands/pkg_install'
   require "minipack/version"
-
-  INSTALLER_WATCHED_PATHS = ['package.json', 'package-lock.json', 'yarn.lock'].freeze
 
   class << self
     def configuration(&block)
@@ -22,20 +22,6 @@ module Minipack
       @configuration
     end
     attr_writer :configuration
-
-    def install(logger: nil)
-      configuration.leaves.each do |c|
-        build_cache_key = INSTALLER_WATCHED_PATHS.map { |f| File.expand_path(f, c.resolved_base_path) }
-        watcher = FileChangeWatcher.new(build_cache_key, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
-        CommandRunner.new(
-          {},
-          c.pkg_install_command,
-          chdir: c.resolved_base_path,
-          logger: logger,
-          watcher: watcher,
-        ).run!
-      end
-    end
 
     # Find all 'minipack_plugin' files in $LOAD_PATH and load them
     def load_env_plugins

--- a/lib/minipack.rb
+++ b/lib/minipack.rb
@@ -29,7 +29,7 @@ module Minipack
         watcher = FileChangeWatcher.new(build_cache_key, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
         CommandRunner.new(
           {},
-          c.install_command,
+          c.pkg_install_command,
           chdir: c.resolved_base_path,
           logger: logger,
           watcher: watcher,

--- a/lib/minipack/commands/base.rb
+++ b/lib/minipack/commands/base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Minipack
+  module Commands
+    class Base
+      class << self
+        def call(*args)
+          new(*args).call
+        end
+      end
+    end
+  end
+end

--- a/lib/minipack/commands/build.rb
+++ b/lib/minipack/commands/build.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base'
-
 module Minipack
   module Commands
     class Build < Base

--- a/lib/minipack/commands/build.rb
+++ b/lib/minipack/commands/build.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Minipack
+  module Commands
+    class Build < Base
+      def initialize(logger: nil)
+        @logger = logger
+      end
+
+      def call
+        Minipack.configuration.leaves.each do |c|
+          # Note: someone wants pre_build hook?
+          build(c)
+          # Note: someone wants post_build hook?
+         end
+        true
+      end
+
+      private
+
+      def build(c)
+        watcher = FileChangeWatcher.new(c.resolved_build_cache_key, File.join(c.cache_path, "last-build-digest-#{c.id}-#{::Rails.env}"))
+        CommandRunner.new(
+          {},
+          c.build_command,
+          chdir: c.resolved_base_path,
+          logger: @logger,
+          watcher: watcher,
+        ).run!
+      end
+    end
+  end
+end

--- a/lib/minipack/commands/pkg_install.rb
+++ b/lib/minipack/commands/pkg_install.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Minipack
+  module Commands
+    class PkgInstall < Base
+      PKG_INSTALL_CACHE_KEY = ['package.json', 'package-lock.json', 'yarn.lock'].freeze
+
+      def initialize(logger: nil)
+        @logger = logger
+      end
+
+      def call
+        Minipack.configuration.leaves.each do |c|
+          # Note: someone wants pre_pkg_install hook?
+          pkg_install(c)
+          # Note: someone wants post_pkg_install hook?
+         end
+        true
+      end
+
+      private
+
+      def pkg_install(c)
+        pkg_install_cache_key = PKG_INSTALL_CACHE_KEY.map { |f| File.expand_path(f, c.resolved_base_path) }
+        watcher = FileChangeWatcher.new(pkg_install_cache_key, File.join(c.cache_path, "last-installation-digest-#{c.id}-#{::Rails.env}"))
+        CommandRunner.new(
+          {},
+          c.pkg_install_command,
+          chdir: c.resolved_base_path,
+          logger: @logger,
+          watcher: watcher,
+        ).run!
+      end
+    end
+  end
+end

--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -70,11 +70,17 @@ module Minipack
       # The command for bundling assets
       config_attr :build_command, default: 'node_modules/.bin/webpack'
 
-      # Let me leave this line for remember the indea of post build hooks
+      # Let me leave this line to remember the indea of post build hooks
       # config_attr :post_build_hooks, default: []
+
+      # Let me leave this line to remember the indea of pre pkg install hooks
+      # config_attr :pre_pkg_install_hooks, default: []
 
       # The command for installation of npm packages
       config_attr :pkg_install_command, default: 'npm install'
+
+      # Let me leave this line for remember the indea of post pkg install hooks
+      # config_attr :post_install_hooks, default: []
 
       # Initializes a new instance of Configuration class.
       #

--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -64,8 +64,14 @@ module Minipack
       # The lazy compilation is cached until a file is change under the tracked paths.
       config_attr :build_cache_key, default: BUILD_CACHE_KEY_DEFAULT.dup
 
+      # Let me leave this line for remember the indea of pre build hooks
+      # config_attr :pre_build_hooks, default: []
+
       # The command for bundling assets
       config_attr :build_command, default: 'node_modules/.bin/webpack'
+
+      # Let me leave this line for remember the indea of post build hooks
+      # config_attr :post_build_hooks, default: []
 
       # The command for installation of npm packages
       config_attr :install_command, default: 'npm install'

--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -25,7 +25,7 @@ module Minipack
       class Error < StandardError; end
 
       ROOT_DEFAULT_ID = :''
-      WATCHED_PATHS_DEFAULT = [
+      BUILD_CACHE_KEY_DEFAULT = [
         'package.json',
         'package-lock.json',
         'yarn.lock',
@@ -62,7 +62,7 @@ module Minipack
       config_attr :manifest
 
       # The lazy compilation is cached until a file is change under the tracked paths.
-      config_attr :watched_paths, default: WATCHED_PATHS_DEFAULT.dup
+      config_attr :build_cache_key, default: BUILD_CACHE_KEY_DEFAULT.dup
 
       # The command for bundling assets
       config_attr :build_command, default: 'node_modules/.bin/webpack'
@@ -136,12 +136,12 @@ module Minipack
         File.expand_path(base_path || '.', root_path)
       end
 
-      # Resolve watched_paths as absolute paths
+      # Resolve build_cache_key as absolute paths
       #
       # @return [Array<String>]
-      def resolved_watched_paths
+      def resolved_build_cache_key
         base = resolved_base_path
-        watched_paths.map { |path| File.expand_path(path, base) }
+        build_cache_key.map { |path| File.expand_path(path, base) }
       end
 
       # @return [String]

--- a/lib/minipack/configuration.rb
+++ b/lib/minipack/configuration.rb
@@ -74,7 +74,7 @@ module Minipack
       # config_attr :post_build_hooks, default: []
 
       # The command for installation of npm packages
-      config_attr :install_command, default: 'npm install'
+      config_attr :pkg_install_command, default: 'npm install'
 
       # Initializes a new instance of Configuration class.
       #

--- a/lib/minipack/rspec.rb
+++ b/lib/minipack/rspec.rb
@@ -5,7 +5,7 @@ RSpec.configure do |c|
     logger = Logger.new(STDOUT).tap do |l|
       l.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
     end
-    Minipack.install(logger: logger)
+    Minipack::Commands::PkgInstall.call(logger: logger)
     Minipack::Commands::Build.call(logger: logger)
   end
 end

--- a/lib/minipack/rspec.rb
+++ b/lib/minipack/rspec.rb
@@ -6,6 +6,6 @@ RSpec.configure do |c|
       l.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
     end
     Minipack.install(logger: logger)
-    Minipack.build(logger: logger)
+    Minipack::Commands::Build.call(logger: logger)
   end
 end

--- a/spec/minipack/configuration_spec.rb
+++ b/spec/minipack/configuration_spec.rb
@@ -315,8 +315,8 @@ RSpec.describe Minipack::Configuration do
     end
   end
 
-  describe '#resolved_watched_paths' do
-    subject { config.resolved_watched_paths }
+  describe '#resolved_build_cache_key' do
+    subject { config.resolved_build_cache_key }
 
     let(:config) { described_class.new }
 
@@ -327,7 +327,7 @@ RSpec.describe Minipack::Configuration do
 
     context 'when the pass is relative' do
       before do
-        config.watched_paths = ['package.json']
+        config.build_cache_key = ['package.json']
       end
 
       it 'is resolved based on base_dir' do
@@ -337,7 +337,7 @@ RSpec.describe Minipack::Configuration do
 
     context 'when the pass is absolute' do
       before do
-        config.watched_paths = ['/app/frontend/package.json']
+        config.build_cache_key = ['/app/frontend/package.json']
       end
 
       it 'is resolved to the value you set' do


### PR DESCRIPTION
Introduced command layer, to clarify the two use cases below:

* Minipack can build assets. Because it must be done before doing something(like running test).
* Minipack can install packages. Because it must be run before Minipack build assets.

Note that the configuration keys below have been renamed

* watched_paths -> build_cache_key - because `watched` too much expose internal implementation. Instead cache key is better.
* install_command -> pkg_install_command - because install imagines such as installing vue, installing webpack. To clarify, add `pkg` prefix to represent package manager.